### PR TITLE
feat(example): add simple_web_server simulated example

### DIFF
--- a/examples/simple_web_server/README.md
+++ b/examples/simple_web_server/README.md
@@ -1,0 +1,15 @@
+# Simple Web Server (simulated)
+
+Demonstrates wiring a simulated HTTP server using built-in nodes. Uses `HttpServerNode.simulate_request()` to inject requests without a real server.
+
+## Run
+
+```bash
+python examples/simple_web_server/main.py
+```
+
+## What it shows
+- Routing with `Router`
+- Simple transformation with `MapTransformer`
+- Metrics collection with `MetricsCollectorNode`
+- Serialization with `SerializationNode`

--- a/examples/simple_web_server/main.py
+++ b/examples/simple_web_server/main.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import threading
+import time
+
+from meridian.core import Scheduler, SchedulerConfig, Subgraph
+from meridian.nodes import (
+    HttpServerNode,
+    MapTransformer,
+    MetricsCollectorNode,
+    Router,
+    SerializationNode,
+)
+
+
+def build_graph() -> Subgraph:
+    srv = HttpServerNode("srv")
+
+    router = Router(
+        "router",
+        routing_fn=lambda req: "metrics" if isinstance(req, dict) and req.get("path") == "/metrics" else "echo",
+        output_ports=["metrics", "echo"],
+    )
+
+    metrics = MetricsCollectorNode(
+        "metrics",
+        metric_extractors={"requests": lambda req: 1.0},
+        aggregation_window_ms=50,
+    )
+
+    echo = MapTransformer("echo", transform_fn=lambda req: {"path": req.get("path"), "ok": True})
+
+    ser = SerializationNode("ser")
+
+    g = Subgraph.from_nodes("web", [srv, router, metrics, echo, ser])
+    g.connect(("srv", "output"), ("router", "input"))
+    g.connect(("router", "metrics"), ("metrics", "input"))
+    g.connect(("router", "echo"), ("echo", "input"))
+    g.connect(("metrics", "output"), ("ser", "input"))
+    g.connect(("echo", "output"), ("ser", "input"))
+    return g
+
+
+def main() -> None:
+    g = build_graph()
+    sched = Scheduler(SchedulerConfig(idle_sleep_ms=0, tick_interval_ms=5))
+    sched.register(g)
+
+    th = threading.Thread(target=sched.run, daemon=True)
+    th.start()
+
+    srv = next(n for n in g.nodes if getattr(n, "name", "") == "srv")
+    assert isinstance(srv, HttpServerNode)
+
+    for path in ["/", "/echo", "/metrics", "/echo"]:
+        srv.simulate_request("GET", path)
+
+    time.sleep(0.2)
+    sched.shutdown()
+    th.join()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds examples/simple_web_server with a runnable main.py and README matching docs.